### PR TITLE
Update initialization to work with latest Arduino Mbed board packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It was designed for the **Arduino nano 33 BLE** and tested with _GNU/Linux, Andr
 
 ## Environment
 
-On the Arduino IDE you will need the **Arduino nRF528x boards (Mbed OS)** with version **1.1.6** (In the menu bar click on "_Tools > Boards > Boards manager.._").
+On the Arduino IDE you will need the **Arduino mbed-enabled Boards** with version **1.3.1** or higher (In the menu bar click on "_Tools > Boards > Boards manager.._").
 
 Alternatively you can use [platformio](https://github.com/platformio) [Deviot](https://github.com/platformio/Deviot).
 

--- a/src/Mbed_BLE_HID.cpp
+++ b/src/Mbed_BLE_HID.cpp
@@ -102,14 +102,6 @@ void MbedBleHID::postInitialization(BLE &ble)
   Gap &gap = ble.gap();
   gap.setEventHandler(this);
 
-  const Gap::ConnectionParams_t connectionParams = {
-    7,          // min conn interval
-    15,         // max conn interval
-    0,          // slave latency
-    3200        // supervision timeout
-  };
-  gap.setPreferredConnectionParams(&connectionParams);
-
   // GAP Advertising parameters.
   {
     using namespace ble;
@@ -117,8 +109,8 @@ void MbedBleHID::postInitialization(BLE &ble)
     gap.setAdvertisingPayload(
       LEGACY_ADVERTISING_HANDLE,
       AdvertisingDataSimpleBuilder<LEGACY_ADVERTISING_MAX_SIZE>()
-        .setFlags(GapAdvertisingData::BREDR_NOT_SUPPORTED 
-                | GapAdvertisingData::LE_GENERAL_DISCOVERABLE
+        .setFlags(adv_data_flags_t::BREDR_NOT_SUPPORTED 
+                | adv_data_flags_t::LE_GENERAL_DISCOVERABLE
         )
         .setName(kDeviceName_.c_str(), true)
         .setAppearance(services_.hid->appearance())


### PR DESCRIPTION
Tested with v1.3.1, should fix https://github.com/tcoppex/mbed-ble-hid/issues/3.

It does remove the setting of the preferred connection parameters, since that seems to be gone from the default Gap glass in the latest BLE code, though it's present in some derived children. It doesn't seem to affect the applications I'm using this for though.