### PR TITLE
Add mbed_nano to list of compatible architectures

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,6 +6,6 @@ sentence=A Library to implement Human Interface Device with Bluetooth on a Mbed 
 paragraph=Provide ready to use HID (mouse, keyboard, gamepad) and customization classes.
 category=Communication
 url=https://github.com/tcoppex/mbed-ble-hid
-architectures=mbed
+architectures=mbed,mbed_nano
 includes=Mbed_BLE_HID.h, Nano33BleHID.h
 


### PR DESCRIPTION
In the recent 2.0.0 release of the Arduino Mbed OS Boards platform, the mbed architecture split into four architectures:

- mbed_edge: Arduino Edge Control
- mbed_nano: Nano 33 BLE and Nano RP2040 Connect
- mbed_rp2040: Raspberry Pi Pico
- mbed_portenta: Portenta H7

The mbed architecture should be retained for backwards support, but the new mbed_nano should also be added to avoid spurious incompatibility warnings and the library's examples being shown under the File > Examples > INCOMPATIBLE menu of the Arduino IDE when the Nano 33 BLE board is selected.